### PR TITLE
fix(expenses): implementar templates de confirmação para categorias e orçamentos

### DIFF
--- a/expenses/templates/expenses/budget_confirm_delete.html
+++ b/expenses/templates/expenses/budget_confirm_delete.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block breadcrumb %}FinTrack / Orçamentos / Excluir Meta{% endblock %}
+
+{% block content %}
+<div class="max-w-md mx-auto">
+    <!-- Card de Confirmação -->
+    <div class="bg-white p-10 rounded-[2.5rem] shadow-sm border border-gray-100 text-center">
+        
+        <!-- Ícone de Alerta -->
+        <div class="h-20 w-20 bg-red-50 text-red-500 rounded-3xl flex items-center justify-center mx-auto mb-6">
+            <i class="fas fa-bullseye text-3xl"></i>
+        </div>
+
+        <h2 class="text-2xl font-black text-gray-800 mb-4 tracking-tight">Excluir Meta?</h2>
+        
+        <p class="text-gray-500 text-sm mb-8 leading-relaxed">
+            Você está prestes a remover a meta de gastos da categoria <strong class="text-slate-800">"{{ budget.category.name }}"</strong> para o período de {{ budget.month }}/{{ budget.year }}.
+        </p>
+        
+        <!-- Formulário de Deleção -->
+        <form method="post" class="flex flex-col gap-3">
+            {% csrf_token %}
+            <button type="submit" class="w-full bg-red-500 text-white px-6 py-4 rounded-2xl font-black uppercase tracking-widest hover:bg-red-600 transition shadow-lg shadow-red-100 active:scale-95">
+                Confirmar Exclusão
+            </button>
+            <a href="{% url 'expenses:budget_list' %}" class="w-full bg-gray-50 text-gray-500 px-6 py-4 rounded-2xl font-bold text-center hover:bg-gray-100 transition">
+                Manter Meta
+            </a>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/expenses/views.py
+++ b/expenses/views.py
@@ -217,7 +217,9 @@ def budget_delete(request, pk):
     budget = get_object_or_404(Budget, pk=pk, user=request.user)
     if request.method == 'POST':
         budget.delete()
+        messages.success(request, "Meta removida com sucesso!")
         return redirect('expenses:budget_list')
+    
     return render(request, 'expenses/budget_confirm_delete.html', {'budget': budget})
 
 @login_required


### PR DESCRIPTION
> #### Objetivo
> Resolver o erro `TemplateDoesNotExist` que ocorria ao tentar excluir categorias ou metas financeiras, completando o fluxo de deleção do sistema.
> 
> #### Alterações
> - Criação do template `category_confirm_delete.html`.
> - Criação do template `budget_confirm_delete.html`.
> - Padronização visual dos modais de confirmação seguindo a identidade "Premium" do projeto.
> - Inclusão de avisos sobre o impacto das exclusões nos dados vinculados.